### PR TITLE
Add module-specific pages

### DIFF
--- a/src/classes/classes.html
+++ b/src/classes/classes.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en_US">
+  <head>
+    <meta charset="utf-8" />
+    <meta content="IE=Edge" http-equiv="X-UA-Compatible" />
+    <meta
+      name="viewport"
+      content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=0"
+    />
+    <link
+      rel="stylesheet"
+      href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"
+      integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u"
+      crossorigin="anonymous"
+    />
+  </head>
+  <body>
+    <div class="container" style="display: flex">
+      <div style="flex: 5">
+        <h5>Edit the Javascript that powers me in src/index.js</h5>
+        <h1>Omnisearch</h1>
+        <div class="form-group">
+          <label for="searchField">Search everything in one place</label>
+          <input class="form-control" type="text" id="searchField" />
+        </div>
+        <div class="row">
+          <div class="col-lg-6 col-md-12">
+            <div class="panel panel-default">
+              <div class="panel-heading">
+                <h3 class="panel-title">Reddit</h3>
+              </div>
+              <div id="reddit" class="panel-body"></div>
+            </div>
+          </div>
+          <div class="col-lg-6 col-md-12">
+            <div class="panel panel-default">
+              <div class="panel-heading">
+                <h3 class="panel-title">Hacker News</h3>
+              </div>
+              <div id="hacker-news" class="panel-body"></div>
+            </div>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col-lg-6 col-md-12">
+            <div class="panel panel-default">
+              <div class="panel-heading">
+                <h3 class="panel-title">Locations</h3>
+              </div>
+              <div id="locations" class="panel-body"></div>
+            </div>
+          </div>
+          <div class="col-lg-6 col-md-12">
+            <div class="panel panel-default">
+              <div class="panel-heading"><h3 class="panel-title">Books</h3></div>
+              <div id="books" class="panel-body"></div>
+            </div>
+          </div>
+        </div>
+        <div class="row">
+          <div id="last-search-time" class="col-sm-12"></div>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/src/classes/classes.html
+++ b/src/classes/classes.html
@@ -17,7 +17,7 @@
   <body>
     <div class="container" style="display: flex">
       <div style="flex: 5">
-        <h5>Edit the Javascript that powers me in src/index.js</h5>
+        <h5>Edit the Javascript that powers me in src/classes/classes.js</h5>
         <h1>Omnisearch</h1>
         <div class="form-group">
           <label for="searchField">Search everything in one place</label>

--- a/src/classes/classes.js
+++ b/src/classes/classes.js
@@ -1,0 +1,238 @@
+const maxItemsToDisplay = 5;
+const CACHE = {};
+
+function updateCache(id, searchTerm, data) {
+  CACHE[id] = CACHE[id] || {};
+  CACHE[id][searchTerm] = data;
+}
+
+function itemFromCache(id, searchTerm) {
+  CACHE[id] && CACHE[id][searchTerm];
+}
+
+// add event listener to the search field input
+document.getElementById("searchField").addEventListener("input", function() {
+  onSearchFieldInputChange();
+});
+
+// data feed setup
+let dataFeeds = {
+  reddit: {
+    id: "reddit",
+    url:
+      "https://api.reddit.com/api/subreddit_autocomplete_v2.json?limit=10&include_over_18=false&query=",
+    normaliseData: function(data) {
+      let normalisedData = [];
+      let data = data.data;
+      let i;
+      let dataLength = 0;
+      let addDisplayItem = function(item) {
+        let displayItem = {};
+        let createdDate = new Date(1000 * item.created);
+        displayItem.col1 = createdDate.toLocaleDateString();
+        displayItem.col2 = item.subscribers || "0";
+        displayItem.col3 =
+          '<a href="https://reddit.com' + item.url + '">' + item.title + "</a>";
+        normalisedData.push(displayItem);
+      };
+      if (data && data.children && data.children.length) {
+        dataLength = data.children.length;
+        for (i = 0; i < dataLength; i++) {
+          if (normalisedData.length >= maxItemsToDisplay) {
+            break;
+          }
+          addDisplayItem(data.children[i].data);
+        }
+      }
+      return normalisedData;
+    }
+  },
+  "hacker-news": {
+    id: "hacker-news",
+    url: "http://hn.algolia.com/api/v1/search?hitsPerPage=10&query=",
+    normaliseData: function(data) {
+      let normalisedData = [];
+      let hits = data.hits;
+      let i;
+      let dataLength = 0;
+      let addDisplayItem = function(item) {
+        let displayItem = {};
+        let createdDate = new Date(item.created_at);
+        displayItem.col1 = createdDate.toLocaleDateString();
+        displayItem.col2 = item.points;
+        displayItem.col3 = '<a href="' + item.url + '">' + item.title + "</a>";
+        normalisedData.push(displayItem);
+      };
+      if (hits && hits.length) {
+        dataLength = hits.length;
+        for (i = 0; i < dataLength; i++) {
+          if (normalisedData.length >= maxItemsToDisplay) {
+            break;
+          }
+          addDisplayItem(hits[i]);
+        }
+      }
+      return normalisedData;
+    }
+  },
+  locations: {
+    id: "locations",
+    url:
+      "https://nominatim.openstreetmap.org/search?format=json&addressdetails=1&q=",
+    normaliseData: function(data) {
+      let normalisedData = [];
+      let i;
+      let dataLength = 0;
+      let addDisplayItem = function(item) {
+        let displayItem = {};
+        displayItem.col1 = item.display_name;
+        displayItem.col2 = item.lat + "," + item.lon;
+        normalisedData.push(displayItem);
+      };
+      if (data && data.length) {
+        dataLength = data.length;
+        for (i = 0; i < dataLength; i++) {
+          if (normalisedData.length >= maxItemsToDisplay) {
+            break;
+          }
+          addDisplayItem(data[i]);
+        }
+      }
+      return normalisedData;
+    }
+  },
+  books: {
+    id: "books",
+    url:
+      "http://openlibrary.org/query.json?type=/type/edition&limit=10&*=&title=",
+    normaliseData: function(data) {
+      let normalisedData = [];
+      let i;
+      let dataLength = 0;
+      let addDisplayItem = function(item) {
+        let subjectList = item.subjects && item.subjects.join("; ");
+        let displayItem = {};
+        displayItem.col1 = item.title;
+        displayItem.col2 = item.subtitle || " ";
+        displayItem.col3 = subjectList || " ";
+        displayItem.col4 = item.publish_date;
+        normalisedData.push(displayItem);
+      };
+      if (data && data.length) {
+        dataLength = data.length;
+        for (i = 0; i < dataLength; i++) {
+          if (normalisedData.length >= maxItemsToDisplay) {
+            break;
+          }
+          addDisplayItem(data[i]);
+        }
+      }
+      return normalisedData;
+    }
+  }
+};
+
+function fetchData(props) {
+  let id = props.id;
+  let url = props.url;
+  let searchTerm = props.searchTerm;
+  let normaliseData = props.normaliseData;
+  if (navigator.onLine) {
+    fetch(url + encodeURIComponent(searchTerm))
+      .then(function(response) {
+        return response.json();
+      })
+      .then(function(json) {
+        let data = normaliseData(json);
+        updateCache(id, searchTerm, data);
+        updateSearchDisplay({ id: id, data: data });
+      });
+  } else {
+    if (itemFromCache(id, searchTerm)) {
+      updateSearchDisplay({
+        id: id,
+        data: itemFromCache(id, searchTerm),
+        offline: true
+      });
+    } else {
+      updateSearchDisplay({ id: id, offline: true });
+    }
+  }
+}
+
+function onSearchFieldInputChange() {
+  let searchTerm = document.getElementById("searchField").value;
+  let fetchDataFeed = function(dataFeed) {
+    let feedProps = {};
+    feedProps.id = dataFeed.id;
+    feedProps.url = dataFeed.url;
+    feedProps.normaliseData = dataFeed.normaliseData;
+    feedProps.searchTerm = searchTerm;
+    fetchData(feedProps);
+  };
+  Object.keys(dataFeeds).forEach(function(key) {
+    fetchDataFeed(dataFeeds[key]);
+  });
+  updateLastSearchTime({ searchTerm: searchTerm });
+}
+
+function updateSearchDisplay(props) {
+  let searchDisplayHtml = "";
+  let id = props.id;
+  let data = props.data;
+  let offline = props.offline;
+  if (offline && data && data.length) {
+    searchDisplayHtml +=
+      '<div style="margin-bottom: 12px;">Offline - displaying cached results</div>';
+  } else if (offline) {
+    searchDisplayHtml += "<div>Offline</div>";
+  }
+  if (data && data.length) {
+    searchDisplayHtml += '<table class="table table-striped">';
+    searchDisplayHtml += "<tbody>";
+
+    data.map(function(columns) {
+      searchDisplayHtml += "<tr>";
+      if (columns.col1) {
+        searchDisplayHtml += "<td>";
+        searchDisplayHtml += columns.col1;
+        searchDisplayHtml += "</td>";
+      }
+      if (columns.col2) {
+        searchDisplayHtml += "<td>";
+        searchDisplayHtml += columns.col2;
+        searchDisplayHtml += "</td>";
+      }
+      if (columns.col3) {
+        searchDisplayHtml += "<td>";
+        searchDisplayHtml += columns.col3;
+        searchDisplayHtml += "</td>";
+      }
+      if (columns.col4) {
+        searchDisplayHtml += "<td>";
+        searchDisplayHtml += columns.col4;
+        searchDisplayHtml += "</td>";
+      }
+      searchDisplayHtml += "</tr>";
+    });
+
+    searchDisplayHtml += "</tbody>";
+    searchDisplayHtml += "</table>";
+  }
+  document.getElementById(id).innerHTML = searchDisplayHtml;
+}
+
+function updateLastSearchTime(props) {
+  let lastSearchTimeHtml = "";
+  let timestamp;
+  if (props.searchTerm) {
+    timestamp = new Date();
+    lastSearchTimeHtml =
+      "<small>Last search: " +
+      timestamp.toLocaleDateString() +
+      " " +
+      timestamp.toLocaleTimeString() +
+      "</small>";
+  }
+  document.getElementById("last-search-time").innerHTML = lastSearchTimeHtml;
+}

--- a/src/classes/classes.js
+++ b/src/classes/classes.js
@@ -23,7 +23,7 @@ let dataFeeds = {
       "https://api.reddit.com/api/subreddit_autocomplete_v2.json?limit=10&include_over_18=false&query=",
     normaliseData: function(data) {
       let normalisedData = [];
-      let data = data.data;
+      var data = data.data;
       let i;
       let dataLength = 0;
       let addDisplayItem = function(item) {

--- a/src/index.html
+++ b/src/index.html
@@ -15,49 +15,57 @@
     />
   </head>
   <body>
-    <div class="container">
-      <h5>Edit the Javascript that powers me in src/index.js</h5>
-      <h1>Omnisearch</h1>
-      <div class="form-group">
-        <label for="searchField">Search everything in one place</label>
-        <input class="form-control" type="text" id="searchField" />
+    <div class="container" style="display: flex">
+      <div class="sidebar" style="flex: 1">
+        <div>
+          <em>Other modules</em>
+        </div>
+        <a href="/classes/classes.html">Classes module</a>
       </div>
-      <div class="row">
-        <div class="col-lg-6 col-md-12">
-          <div class="panel panel-default">
-            <div class="panel-heading">
-              <h3 class="panel-title">Reddit</h3>
+      <div style="flex: 5">
+        <h5>Edit the Javascript that powers me in src/index.js</h5>
+        <h1>Omnisearch</h1>
+        <div class="form-group">
+          <label for="searchField">Search everything in one place</label>
+          <input class="form-control" type="text" id="searchField" />
+        </div>
+        <div class="row">
+          <div class="col-lg-6 col-md-12">
+            <div class="panel panel-default">
+              <div class="panel-heading">
+                <h3 class="panel-title">Reddit</h3>
+              </div>
+              <div id="reddit" class="panel-body"></div>
             </div>
-            <div id="reddit" class="panel-body"></div>
           </div>
-        </div>
-        <div class="col-lg-6 col-md-12">
-          <div class="panel panel-default">
-            <div class="panel-heading">
-              <h3 class="panel-title">Hacker News</h3>
+          <div class="col-lg-6 col-md-12">
+            <div class="panel panel-default">
+              <div class="panel-heading">
+                <h3 class="panel-title">Hacker News</h3>
+              </div>
+              <div id="hacker-news" class="panel-body"></div>
             </div>
-            <div id="hacker-news" class="panel-body"></div>
           </div>
         </div>
-      </div>
-      <div class="row">
-        <div class="col-lg-6 col-md-12">
-          <div class="panel panel-default">
-            <div class="panel-heading">
-              <h3 class="panel-title">Locations</h3>
+        <div class="row">
+          <div class="col-lg-6 col-md-12">
+            <div class="panel panel-default">
+              <div class="panel-heading">
+                <h3 class="panel-title">Locations</h3>
+              </div>
+              <div id="locations" class="panel-body"></div>
             </div>
-            <div id="locations" class="panel-body"></div>
+          </div>
+          <div class="col-lg-6 col-md-12">
+            <div class="panel panel-default">
+              <div class="panel-heading"><h3 class="panel-title">Books</h3></div>
+              <div id="books" class="panel-body"></div>
+            </div>
           </div>
         </div>
-        <div class="col-lg-6 col-md-12">
-          <div class="panel panel-default">
-            <div class="panel-heading"><h3 class="panel-title">Books</h3></div>
-            <div id="books" class="panel-body"></div>
-          </div>
+        <div class="row">
+          <div id="last-search-time" class="col-sm-12"></div>
         </div>
-      </div>
-      <div class="row">
-        <div id="last-search-time" class="col-sm-12"></div>
       </div>
     </div>
   </body>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,13 +4,15 @@ const HTMLWebpackPlugin = require("html-webpack-plugin")
 const Index = new HTMLWebpackPlugin({
   template: path.join(__dirname, "/src/index.html"),
   filename: "index.html",
-  inject: "body"
+  inject: "body",
+  chunks: ["main"],
 })
 
 const Classes = new HTMLWebpackPlugin({
   template: path.join(__dirname, "/src/classes/classes.html"),
   filename: "classes/classes.html",
   inject: "body",
+  chunks: ["classes"],
 })
 
 module.exports = {
@@ -22,10 +24,13 @@ module.exports = {
     },
     historyApiFallback: true
   },  
-  entry: [path.join(__dirname, "/src/index.js")],
+  entry: {
+    main: path.join(__dirname, "/src/index.js"),
+    classes: path.join(__dirname, "/src/classes/classes.js"),
+  },
   output: {
     path: path.join(__dirname, "/build"),
-    filename: 'index.js'
+    filename: '[name].js'
   },  
   module: {
     rules: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,10 +1,16 @@
 const path = require("path")
 const HTMLWebpackPlugin = require("html-webpack-plugin")
 
-const HTMLWebpackPluginConfig = new HTMLWebpackPlugin({
+const Index = new HTMLWebpackPlugin({
   template: path.join(__dirname, "/src/index.html"),
   filename: "index.html",
   inject: "body"
+})
+
+const Classes = new HTMLWebpackPlugin({
+  template: path.join(__dirname, "/src/classes/classes.html"),
+  filename: "classes/classes.html",
+  inject: "body",
 })
 
 module.exports = {
@@ -32,5 +38,5 @@ module.exports = {
       }
     ]
   },
-  plugins: [HTMLWebpackPluginConfig]
+  plugins: [Index, Classes]
 };


### PR DESCRIPTION
This PR proposes a quick-fire way for me to split module-specific exercises from the shared `index.html` / `index.js` without lots of faff in the module setup instructions and the overall webpack / npm setup for the codebase, and avoid (unexpected) knock on effects in unrelated module exercises.

I've added a sidenav that links to new files specific to each module (in this case, `classes`). This allows me to isolate and reorg the exercise for that module with relatively easy to follow instructions specific to that module and no changes to the shared setup.

It is probably inelegant but it's what I've come up with as a quick way to build out the `modern_js` modules within a time box.
